### PR TITLE
Fix the INI parser.

### DIFF
--- a/dunstify.c
+++ b/dunstify.c
@@ -199,7 +199,7 @@ void closed(NotifyNotification *n, gpointer foo)
 void add_action(NotifyNotification *n, char *str)
 {
     char *action = str;
-    char *label = strstr(str, ",");
+    char *label = strchr(str, ',');
 
     if (!label || *(label+1) == '\0') {
         g_printerr("Malformed action. Excpected \"action,label\", got \"%s\"", str);
@@ -215,14 +215,14 @@ void add_action(NotifyNotification *n, char *str)
 void add_hint(NotifyNotification *n, char *str)
 {
     char *type = str;
-    char *name = strstr(str, ":");
+    char *name = strchr(str, ':');
     if (!name || *(name+1) == '\0') {
         g_printerr("Malformed hint. Expected \"type:name:value\", got \"%s\"", str);
         return;
     }
     *name = '\0';
     name++;
-    char *value = strstr(name, ":");
+    char *value = strchr(name, ':');
     if (!value || *(value+1) == '\0') {
         g_printerr("Malformed hint. Expected \"type:name:value\", got \"%s\"", str);
         return;

--- a/notification.c
+++ b/notification.c
@@ -305,8 +305,7 @@ int notification_init(notification * n, int id)
         }
 
         if (settings.ignore_newline)
-                while (strstr(n->msg, "\n") != NULL)
-                        n->msg = string_replace("\n", " ", n->msg);
+                n->msg = string_replace_char('\n', ' ', n->msg);
 
         n->msg = g_strstrip(n->msg);
 

--- a/option_parser.c
+++ b/option_parser.c
@@ -208,7 +208,7 @@ int load_ini_file(FILE * fp)
                         continue;
 
                 if (*start == '[') {
-                        char *end = strstr(start + 1, "]");
+                        char *end = strchr(start + 1, ']');
                         if (!end) {
                                 printf
                                     ("Warning: invalid config file at line %d\n",
@@ -226,7 +226,7 @@ int load_ini_file(FILE * fp)
                         continue;
                 }
 
-                char *equal = strstr(start + 1, "=");
+                char *equal = strchr(start + 1, '=');
                 if (!equal) {
                         printf("Warning: invalid config file at line %d\n",
                                line_num);
@@ -238,9 +238,9 @@ int load_ini_file(FILE * fp)
                 char *key = g_strstrip(start);
                 char *value = g_strstrip(equal + 1);
 
-                char *quote = strstr(value, "\"");
+                char *quote = strchr(value, '"');
                 if (quote) {
-                        char *closing_quote = strstr(quote + 1, "\"");
+                        char *closing_quote = strchr(quote + 1, '"');
                         if (!closing_quote) {
                                 printf
                                     ("Warning: invalid config file at line %d\n",
@@ -251,9 +251,7 @@ int load_ini_file(FILE * fp)
 
                         closing_quote = '\0';
                 } else {
-                        char *comment = strstr(value, "#");
-                        if (!comment)
-                                comment = strstr(value, ";");
+                        char *comment = strpbrk(value, "#;");
                         if (comment)
                                 comment = '\0';
                 }
@@ -285,7 +283,7 @@ int cmdline_find_option(char *key)
                 return -1;
         }
         char *key1 = g_strdup(key);
-        char *key2 = strstr(key1, "/");
+        char *key2 = strchr(key1, '/');
 
         if (key2) {
                 *key2 = '\0';

--- a/x.c
+++ b/x.c
@@ -1082,7 +1082,7 @@ void x_shortcut_init(keyboard_shortcut * ks)
         if (str == NULL)
                 die("Unable to allocate memory", EXIT_FAILURE);
 
-        while (strstr(str, "+")) {
+        while (strchr(str, '+')) {
                 char *mod = str;
                 while (*str != '+')
                         str++;


### PR DESCRIPTION
Fix the INI parser (issue #123). If you don't like this implementation, there are two others in my repo. This one is (IMO) the most readable, and the most modifiable. There is another one that is faster (premature optimization, yada yada), and one that minimizes the changes to the source, but still behaves in slightly odd (but not "wrong") ways.

I apologize for the size of the patch-set.  The earliest commit included is just cleaning up a few string manipulation functions, since I was staring at string manipulation anyway.
